### PR TITLE
Set explicit nofile ulimit for the DC container to 32768.

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       SDC_CONF_RUNNER_THREAD_POOL_SIZE: "200"
     volumes:
       - sdc-data:/data
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
 
   agent:
     image: anodot/daria:latest


### PR DESCRIPTION
The DC container refuses to start if the nofile ulimit is less than 32K. Setting this value explicitly in `docker-compose.yml` will help in environments in which the default is lower (e.g. [AWS ECS](https://docs.amazonaws.cn/en_us/AmazonECS/latest/developerguide/AWS_Fargate.html)).