### PR TITLE
Fix error record creation when there is no data for a given interval

### DIFF
--- a/agent/src/agent/pipeline/config/js_scripts/protocol_3.js
+++ b/agent/src/agent/pipeline/config/js_scripts/protocol_3.js
@@ -64,9 +64,22 @@ function get_measurements(record) {
     return measurements
 }
 
+function last_timestamp_only(record) {
+    var record_keys = [];
+    for (var key in record) {
+        record_keys.push(key)
+    }
+    return (record_keys.length === 1 && record_keys[0] === 'last_timestamp');
+}
 
 for (var i = 0; i < records.length; i++) {
     try {
+        var timestamp_from = records[i].value['last_timestamp']
+		var timestamp_to = records[i].value['last_timestamp'] + state['INTERVAL']
+        if (last_timestamp_only(records[i].value)) {
+            sdc.log.info("No data from " + timestamp_from + " to " + timestamp_to)
+            continue;
+        }
         var timestamp = extract_value(records[i].value, state['TIMESTAMP_COLUMN'])
         if (timestamp === null) {
             continue;

--- a/agent/src/agent/pipeline/config/stages/js_convert_metrics.py
+++ b/agent/src/agent/pipeline/config/stages/js_convert_metrics.py
@@ -26,7 +26,7 @@ state['metrics'] = {{}}
         }
 
     def _required_fields(self) -> list:
-        return [f'/{f}' for f in [*self.pipeline.required_dimension_paths, self.pipeline.timestamp_path]]
+        return [f'/{f}' for f in [*self.pipeline.required_dimension_paths]]
 
 
 class JSConvertMetrics30(JSConvertMetrics):


### PR DESCRIPTION
- Remove /timestamp from required fields list on javascript stage
- Added check that last_timestamp is not a single key in a record on JS stage

Related ticket: [AL-9995](https://anodot.atlassian.net/browse/AL-9995)