### PR TITLE
[agent][dvp] Exclude SHORTROLLUP from dvp_config

### DIFF
--- a/agent/src/agent/pipeline/json_builder/json_schema_definitions/dvp_config.json
+++ b/agent/src/agent/pipeline/json_builder/json_schema_definitions/dvp_config.json
@@ -1,8 +1,8 @@
 {
   "type": "object",
   "properties": {
-    "baseRollup": {"type": "string", "enum": ["SHORTROLLUP", "MEDIUMROLLUP", "LONGROLLUP", "LONGLONGROLLUP", "WEEKLY"]},
-    "maxDVPDurationHours": {"type": "number", "minimum": 1},
+    "baseRollup": {"type": "string", "enum": ["MEDIUMROLLUP", "LONGROLLUP", "LONGLONGROLLUP", "WEEKLY"]},
+    "maxDVPDurationHours": {"type": "number", "minimum": 1, "maximum": 744},
     "gaugeValue": {
         "type": "object", "maxProperties": 2,
         "propertyNames": {"enum": ["keepLastValue", "value"]},

--- a/agent/tests/unit/test_deep_update.py
+++ b/agent/tests/unit/test_deep_update.py
@@ -30,7 +30,7 @@ class TestDeepUpdate(unittest.TestCase):
 
     def test_default_dvp_02(self):
         src_dvp = {
-            'baseRollup': 'SHORTROLLUP',
+            'baseRollup': 'LONGLONGROLLUP',
             'maxDVPDurationHours': 34,
             'preventNoData': False,
             'gaugeValue': {'value': 500, 'keepLastValue': False},
@@ -39,7 +39,7 @@ class TestDeepUpdate(unittest.TestCase):
         deep_update(src_dvp, self.dvp_config_base)
 
         assert self.dvp_config_base == {
-            'baseRollup': 'SHORTROLLUP',
+            'baseRollup': 'LONGLONGROLLUP',
             'maxDVPDurationHours': 34,
             'preventNoData': False,
             'gaugeValue': {'value': 500, 'keepLastValue': False},

--- a/agent/tests/unit/test_dvp_config_validation.py
+++ b/agent/tests/unit/test_dvp_config_validation.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import MagicMock
+
+from agent.pipeline import Pipeline
+from agent.pipeline.json_builder import Builder
+from jsonschema import ValidationError
+
+
+class TestDvpConfigValidation(unittest.TestCase):
+    pipeline_ = MagicMock(spec=Pipeline)
+
+    def test_dvp_config_validate_OK(self):
+        config = {
+            "dvpConfig": {
+                "baseRollup": "LONGROLLUP",
+                "maxDVPDurationHours": 24,
+                "gaugeValue": {"keepLastValue": True},
+                "counterValue": {"value": 0}
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        self.assertIsNone(builder._validate_dvp_config_json_schema())
+
+    def test_dvp_config_fail_SHORTROLLUP(self):
+        config = {
+            "dvpConfig": {
+                "baseRollup": "SHORTROLLUP",
+                "maxDVPDurationHours": 24,
+                "gaugeValue": {"keepLastValue": True},
+                "counterValue": {"value": 5}
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        with self.assertRaises(ValidationError):
+            builder._validate_dvp_config_json_schema()
+
+    def test_dvp_config_fail_maxDVPDurationHours(self):
+        config = {
+            "dvpConfig": {
+                "baseRollup": "LONGLONGROLLUP",
+                "maxDVPDurationHours": 1000,
+                "gaugeValue": {"keepLastValue": True},
+                "counterValue": {"value": 5}
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        with self.assertRaises(ValidationError):
+            builder._validate_dvp_config_json_schema()
+
+    def test_dvp_config_fail_no_baseRollup(self):
+        config = {
+            "dvpConfig": {
+                "maxDVPDurationHours": 24,
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        with self.assertRaises(ValidationError):
+            builder._validate_dvp_config_json_schema()
+
+    def test_dvp_config_fail_no_maxDVPDurationHours(self):
+        config = {
+            "dvpConfig": {
+                "baseRollup": "LONGROLLUP",
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        with self.assertRaises(ValidationError):
+            builder._validate_dvp_config_json_schema()
+
+    def test_dvp_config_fail_gaugeValue_inner(self):
+        config = {
+            "dvpConfig": {
+                "baseRollup": "LONGROLLUP",
+                "maxDVPDurationHours": 24,
+                "gaugeValue": {
+                    "wrong_property": "test"
+                }
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        with self.assertRaises(ValidationError):
+            builder._validate_dvp_config_json_schema()
+
+    def test_dvp_config_fail_counterValue_inner_value(self):
+        config = {
+            "dvpConfig": {
+                "baseRollup": "LONGROLLUP",
+                "maxDVPDurationHours": 10,
+                "gaugeValue": {
+                    "counterValue": {
+                        "value": "str"
+                    }
+                }
+            }
+        }
+        builder = Builder(self.pipeline_, config, False)
+        with self.assertRaises(ValidationError):
+            builder._validate_dvp_config_json_schema()


### PR DESCRIPTION
- Excluded from dvp_config.json validation file
- Added unit tests
- Updated [page](https://github.com/anodot/daria/wiki/Sage), where dvpConfig described

Related ticket: [AL-11090](https://anodot.atlassian.net/browse/AL-11090)