### PR TITLE
[AL-11250] Remove NOT NULL for notification_sent and last_updated col…

### DIFF
--- a/agent/alembic/versions/e9b606f45b76_add_pipeline_retries_last_edited_and_.py
+++ b/agent/alembic/versions/e9b606f45b76_add_pipeline_retries_last_edited_and_.py
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('pipeline_retries', sa.Column('notification_sent', sa.Boolean, nullable=False, default=False))
-    op.add_column('pipeline_retries', sa.Column('last_updated', sa.TIMESTAMP, nullable=False))
+    op.add_column('pipeline_retries', sa.Column('notification_sent', sa.Boolean, default=False))
+    op.add_column('pipeline_retries', sa.Column('last_updated', sa.TIMESTAMP))
 
 
 def downgrade():


### PR DESCRIPTION
- Remove NOT NULL for notification_sent and last_updated columns in pipeline_retries table

Related ticket: [AL-11250](https://anodot.atlassian.net/browse/AL-11250)