### PR TITLE
[agent][metrics]  Fixed pipeline_avg_lag metric

### DIFF
--- a/agent/src/agent/monitoring/metrics.py
+++ b/agent/src/agent/monitoring/metrics.py
@@ -28,7 +28,9 @@ PIPELINE_ERROR_RECORDS = Counter(
     'pipeline_error_records', 'Pipeline error records', ['streamsets_url', 'pipeline_id', 'pipeline_type']
 )
 PIPELINE_AVG_LAG = Gauge(
-    'pipeline_avg_lag', 'Pipeline average lag metrics', ['streamsets_url', 'pipeline_id', 'pipeline_type']
+    'pipeline_avg_lag_seconds',
+    'Pipeline average lag metrics', ['streamsets_url', 'pipeline_id', 'pipeline_type'],
+    multiprocess_mode='max'
 )
 PIPELINE_DESTINATION_LATENCY = Gauge(
     'pipeline_destination_latency_seconds',

--- a/agent/tests/test_monitoring.py
+++ b/agent/tests/test_monitoring.py
@@ -19,7 +19,7 @@ class TestMonitoringMetrics(TestInputBase, TestPipelineBase):
             {'name': 'test_dir_monitoring_csv'},
         ],
         'test_metric_pipeline_avg_lag': [
-            {'name': 'test_dir_monitoring_csv', 'metric_type': 'pipeline_avg_lag'},
+            {'name': 'test_dir_monitoring_csv', 'metric_type': 'pipeline_avg_lag_seconds'},
         ],
         'test_delete_pipeline': [
             {'name': 'test_dir_monitoring_csv'},


### PR DESCRIPTION
- Add multiprocess_mode='max' for PIPELINE_AVG_LAG
- Changed metric name to pipeline_avg_lag_seconds

Related ticket: [AL-11377](https://anodot.atlassian.net/browse/AL-11377)