### PR TITLE
[agent][streamsets] Move credential store files to SDC_DATA

### DIFF
--- a/containers/streamsets/Dockerfile
+++ b/containers/streamsets/Dockerfile
@@ -1,7 +1,7 @@
 FROM streamsets/datacollector:3.18.0-latest
 
 ENV SDC_CONF_PARSER_LIMIT=5048576 SDC_CONF_RUNNER_THREAD_POOL_SIZE="100" STREAMSETS_LIBRARIES_EXTRA_DIR="/opt/sdc-extras/" \
-SDC_LOG="/data/logs"
+SDC_LOG="/data/logs" SDC_JAVA_KEYSTORE_PATH="${SDC_DATA}/security/"
 
 COPY sdc-security.policy ${SDC_CONF}/sdc-security.policy
 COPY credential-stores.properties ${SDC_CONF}/credential-stores.properties
@@ -10,6 +10,7 @@ COPY lib ${USER_LIBRARIES_DIR}
 COPY configure_image.sh /tmp/configure_image.sh
 COPY custom_entrypoint.sh /
 
+RUN mkdir -p ${SDC_JAVA_KEYSTORE_PATH}
 RUN sudo chmod +x /tmp/configure_image.sh && /tmp/configure_image.sh
 
 ## This build uses variable sasl.kerberos.domain.name

--- a/containers/streamsets/credential-stores.properties
+++ b/containers/streamsets/credential-stores.properties
@@ -49,7 +49,7 @@ credentialStore.jks.config.keystore.type=PKCS12
 
 # The location of the Java keystore. Specify an absolute path or a path relative to the
 # $SDC_CONF directory.
-credentialStore.jks.config.keystore.file=jks-credentialStore.pkcs12
+credentialStore.jks.config.keystore.file=/data/security/jks-credentialStore.pkcs12
 
 # The password to access the Java keystore
 credentialStore.jks.config.keystore.storePassword=pass


### PR DESCRIPTION
- `/data/security` is a new path for jks files
- Dockerfile updated

Related ticket: [AL-11436](https://anodot.atlassian.net/browse/AL-11436)