### PR TITLE
[agent][session] FIx SessionManager context exit condition

### DIFF
--- a/agent/src/agent/pipeline/repository.py
+++ b/agent/src/agent/pipeline/repository.py
@@ -135,7 +135,7 @@ class SessionManager:
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
-            self.session.expunge(self.entity)
+            self.session.rollback()
             return False
         self.session.commit()
         return True


### PR DESCRIPTION
- Use rollback for the session instead of expunge in case of exception during update/create pipelines