### PR TITLE
[hotfix][prtg] Fix PRTG request verify parameter

### DIFF
--- a/agent/src/agent/pipeline/config/jython_scripts/prtg.py
+++ b/agent/src/agent/pipeline/config/jython_scripts/prtg.py
@@ -121,7 +121,7 @@ def main():
             offset = get_now() + get_interval()
 
         try:
-            res = session.get(sdc.userParams['URL'], verify=sdc.userParams['VERIFY_SSL'])
+            res = session.get(sdc.userParams['URL'], verify=bool(sdc.userParams['VERIFY_SSL']))
             res.raise_for_status()
             url_parsed = urlparse(sdc.userParams['URL'])
             if url_parsed.path.endswith('.xml'):

--- a/agent/tests/test_pipelines/test_1/test_promql_http.py
+++ b/agent/tests/test_pipelines/test_1/test_promql_http.py
@@ -170,7 +170,7 @@ class TestPromQL(TestPipelineBase):
         schema_id = get_schema_id('test_victoria_dvp')
         # current_day = datetime.now(timezone.utc)
         # month_after_data = current_day.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
-        months_after_data = datetime(year=2022, month=3, day=1, hour=0, minute=0, second=0, microsecond=0).timestamp()
+        months_after_data = datetime(year=2022, month=1, day=1, hour=0, minute=0, second=0, microsecond=0).timestamp()
 
         def correct_watermark():
             try:


### PR DESCRIPTION
**verify** – Either a boolean, in which case it controls whether we verify the server’s TLS certificate, or a string, in which case it must be a path to a CA bundle to use