### PR TITLE
[agent][influx] User/password auth for source type Influx2

### DIFF
--- a/agent/src/agent/pipeline/config/jython_scripts/influx2.py
+++ b/agent/src/agent/pipeline/config/jython_scripts/influx2.py
@@ -30,6 +30,10 @@ def _filter(list_):
     return list(filter(lambda x: bool(x), list_))
 
 
+def _filter_comment(list_):
+    return list(filter(lambda x: not x.startswith('#'), list_))
+
+
 def csv_to_json(csv_data, last_timestamp):
     if not str(csv_data.encode('utf-8')).strip():
         return []
@@ -37,9 +41,10 @@ def csv_to_json(csv_data, last_timestamp):
     data = []
     for result in results:
         rows = result.split('\r\n')
+        rows = _filter_comment(rows)
         header = _filter(rows.pop(0).split(','))
         for row in rows:
-            rec = dict(zip(header, _filter(row.split(','))))
+            rec = dict(zip(reversed(header), reversed(_filter(row.split(',')))))
             rec['last_timestamp'] = last_timestamp
             data.append(rec)
     return data

--- a/agent/src/agent/pipeline/config/stages/source/influx2.py
+++ b/agent/src/agent/pipeline/config/stages/source/influx2.py
@@ -1,5 +1,6 @@
 import os
 
+from base64 import b64encode
 from urllib.parse import urljoin
 from agent import monitoring
 from agent.pipeline.config.stages.influx import InfluxScript
@@ -41,11 +42,26 @@ class Influx2Source(InfluxScript):
         return urljoin(self.pipeline.source.config['host'], f'/api/v2/query?org={self.pipeline.source.config["org"]}')
 
     def _get_headers(self) -> dict:
+        if self.pipeline.source.config.get('token'):
+            auth_header = f'Token {self.pipeline.source.config.get("token")}'
+        else:
+            auth_key = f'{self.pipeline.source.config.get("username")}:{self.pipeline.source.config.get("password")}'
+            auth_header = f'Basic {b64encode(auth_key.encode()).decode("ascii")}'
         return {
-            'Authorization': f'Token {self.pipeline.source.config["token"]}',
+            'Authorization': auth_header,
             'Accept': 'application/csv',
             'Content-type': 'application/json',
         }
+
+    # def _get_auth_header(self):
+    #     if self.pipeline.source.config.get('token'):
+    #         return {'Authorization': f'Token {self.pipeline.source.config.get("token")}'}
+    #     else:
+    #         return {
+    #             'conf.client.authType': 'BASIC',
+    #             'conf.client.basicAuth.username': self.pipeline.source.config.get('username'),
+    #             'conf.client.basicAuth.password': self.pipeline.source.config.get('password', '')
+    #         }
 
     def _get_query(self) -> str:
         query = self.pipeline.query or \

--- a/agent/src/agent/pipeline/config/stages/source/influx2.py
+++ b/agent/src/agent/pipeline/config/stages/source/influx2.py
@@ -56,16 +56,6 @@ class Influx2Source(InfluxScript):
             'Content-type': 'application/json',
         }
 
-    # def _get_auth_header(self):
-    #     if self.pipeline.source.config.get('token'):
-    #         return {'Authorization': f'Token {self.pipeline.source.config.get("token")}'}
-    #     else:
-    #         return {
-    #             'conf.client.authType': 'BASIC',
-    #             'conf.client.basicAuth.username': self.pipeline.source.config.get('username'),
-    #             'conf.client.basicAuth.password': self.pipeline.source.config.get('password', '')
-    #         }
-
     def _get_query(self) -> str:
         query = self.pipeline.query or \
                f'from(bucket:"{self.pipeline.source.config["bucket"]}") ' \

--- a/agent/src/agent/pipeline/config/stages/source/influx2.py
+++ b/agent/src/agent/pipeline/config/stages/source/influx2.py
@@ -39,7 +39,10 @@ class Influx2Source(InfluxScript):
         return params
 
     def _get_url(self) -> str:
-        return urljoin(self.pipeline.source.config['host'], f'/api/v2/query?org={self.pipeline.source.config["org"]}')
+        api_endpoint = '/api/v2/query'
+        if org_param := self.pipeline.source.config.get('org'):
+            api_endpoint += f'?org={org_param}'
+        return urljoin(self.pipeline.source.config['host'], api_endpoint)
 
     def _get_headers(self) -> dict:
         if self.pipeline.source.config.get('token'):

--- a/agent/src/agent/source/json_schema_definitions/influx2.json
+++ b/agent/src/agent/source/json_schema_definitions/influx2.json
@@ -12,6 +12,6 @@
   },
   "oneOf": [
     {"required": ["host", "bucket", "org", "token"]},
-    {"required": ["host", "bucket", "org", "username", "password"]}
+    {"required": ["host", "bucket", "username", "password"]}
   ]
 }

--- a/agent/src/agent/source/json_schema_definitions/influx2.json
+++ b/agent/src/agent/source/json_schema_definitions/influx2.json
@@ -3,10 +3,15 @@
   "properties": {
     "host": {"type": "string"},
     "token": {"type": "string"},
+    "username": {"type": "string"},
+    "password": {"type": "string"},
     "bucket": {"type": "string"},
     "org": {"type": "string"},
     "offset": {"type": "string"},
     "query_timeout": {"type": "integer"}
   },
-  "required": ["host", "token", "bucket", "org"]
+  "oneOf": [
+    {"required": ["host", "bucket", "org", "token"]},
+    {"required": ["host", "bucket", "org", "username", "password"]}
+  ]
 }

--- a/agent/tests/input_files/influx/pipelines.json
+++ b/agent/tests/input_files/influx/pipelines.json
@@ -185,5 +185,17 @@
     },
     "properties": {"test": "val"},
     "interval": 1200000
+  },
+  {
+    "source": "test_influx1_basic_auth",
+    "pipeline_id": "test_influx1_basic_auth",
+    "measurement_name": "cpu_test",
+    "values": {"usage_active": "gauge"},
+    "dimensions": {
+      "required": [],
+      "optional": ["cpu", "host", "zone"]
+    },
+    "properties": {"test": "val"},
+    "interval": 1200000
   }
 ]

--- a/agent/tests/input_files/influx/sources.json
+++ b/agent/tests/input_files/influx/sources.json
@@ -4,6 +4,8 @@
     "name": "test_influx_1",
     "config": {
       "host": "http://influx:8086",
+      "username": "ro",
+      "password": "roro",
       "db": "test"
     }
   },
@@ -12,8 +14,8 @@
     "name": "test_influx",
     "config": {
       "host": "http://influx:8086",
-      "username": "test",
-      "password": "test",
+      "username": "ro",
+      "password": "roro",
       "db": "test",
       "offset": "10/03/2019 12:53"
     }
@@ -23,8 +25,8 @@
     "name": "test_influx_offset",
     "config": {
       "host": "http://influx:8086",
-      "username": "test",
-      "password": "test",
+      "username": "ro",
+      "password": "roro",
       "db": "test",
       "offset": "19/03/2019 12:53"
     }
@@ -58,6 +60,17 @@
       "host": "http://influx2:8086",
       "token": "token",
       "org": "test",
+      "bucket": "test",
+      "offset": "10/03/2019 12:53"
+    }
+  },
+    {
+    "type": "influx2",
+    "name": "test_influx1_basic_auth",
+    "config": {
+      "host": "http://influx:8086",
+      "username": "ro",
+      "password": "roro",
       "bucket": "test",
       "offset": "10/03/2019 12:53"
     }

--- a/agent/tests/test_pipelines/expected_output/influx1_v2_basic_auth.json
+++ b/agent/tests/test_pipelines/expected_output/influx1_v2_basic_auth.json
@@ -1,0 +1,181 @@
+[
+  {
+    "timestamp": 1552654426,
+    "dimensions": {
+      "cpu": "cpu-total-usage",
+      "host": "msk-air-trn5ґ",
+      "zone": "GEO",
+      "test": "val"
+    },
+    "measurements": {
+      "usage_active": 0.204
+    },
+    "schemaId": "test_influx1_basic_auth-1234",
+    "tags": {
+      "source": [
+        "anodot-agent"
+      ],
+      "source_host_id": [
+        "ABCDEF"
+      ],
+      "source_host_name": [
+        "agent"
+      ],
+      "pipeline_id": [
+        "test_influx1_basic_auth"
+      ],
+      "pipeline_type": [
+        "influx2"
+      ]
+    }
+  },
+  {
+    "timestamp": 1552754426,
+    "dimensions": {
+      "cpu": "cpu-total-usage",
+      "host": "msk_a_ir_trn1",
+      "zone": "GF",
+      "test": "val"
+    },
+    "measurements": {
+      "usage_active": 0.224
+    },
+    "schemaId": "test_influx1_basic_auth-1234",
+    "tags": {
+      "source": [
+        "anodot-agent"
+      ],
+      "source_host_id": [
+        "ABCDEF"
+      ],
+      "source_host_name": [
+        "agent"
+      ],
+      "pipeline_id": [
+        "test_influx1_basic_auth"
+      ],
+      "pipeline_type": [
+        "influx2"
+      ]
+    }
+  },
+  {
+    "timestamp": 1552854426,
+    "dimensions": {
+      "cpu": "cpu-total-usage",
+      "host": "msk_air_trn1",
+      "zone": "GF",
+      "test": "val"
+    },
+    "measurements": {
+      "usage_active": 0.22432747346756737
+    },
+    "schemaId": "test_influx1_basic_auth-1234",
+    "tags": {
+      "source": [
+        "anodot-agent"
+      ],
+      "source_host_id": [
+        "ABCDEF"
+      ],
+      "source_host_name": [
+        "agent"
+      ],
+      "pipeline_id": [
+        "test_influx1_basic_auth"
+      ],
+      "pipeline_type": [
+        "influx2"
+      ]
+    }
+  },
+  {
+    "timestamp": 1552954426,
+    "dimensions": {
+      "cpu": "cpu-total-usage",
+      "host": "msk-air-trn1",
+      "test": "val"
+    },
+    "measurements": {
+      "usage_active": 0.224
+    },
+    "schemaId": "test_influx1_basic_auth-1234",
+    "tags": {
+      "source": [
+        "anodot-agent"
+      ],
+      "source_host_id": [
+        "ABCDEF"
+      ],
+      "source_host_name": [
+        "agent"
+      ],
+      "pipeline_id": [
+        "test_influx1_basic_auth"
+      ],
+      "pipeline_type": [
+        "influx2"
+      ]
+    }
+  },
+  {
+    "timestamp": 1553054426,
+    "dimensions": {
+      "cpu": "cpu-total-usage",
+      "host": "msk-air-trn1",
+      "zone": "GF",
+      "test": "val"
+    },
+    "measurements": {
+      "usage_active": 0.504
+    },
+    "schemaId": "test_influx1_basic_auth-1234",
+    "tags": {
+      "source": [
+        "anodot-agent"
+      ],
+      "source_host_id": [
+        "ABCDEF"
+      ],
+      "source_host_name": [
+        "agent"
+      ],
+      "pipeline_id": [
+        "test_influx1_basic_auth"
+      ],
+      "pipeline_type": [
+        "influx2"
+      ]
+    }
+  },
+  {
+    "timestamp": 1553154426,
+    "dimensions": {
+      "cpu": "cpu-total-usage",
+      "host": "msk-air-trn1",
+      "zone": "GEO",
+      "test": "val"
+    },
+    "measurements": {
+      "usage_active": 0.504
+    },
+    "schemaId": "test_influx1_basic_auth-1234",
+    "tags": {
+      "source": [
+        "anodot-agent"
+      ],
+      "source_host_id": [
+        "ABCDEF"
+      ],
+      "source_host_name": [
+        "agent"
+      ],
+      "pipeline_id": [
+        "test_influx1_basic_auth"
+      ],
+      "pipeline_type": [
+        "influx2"
+      ]
+    }
+  }
+]

--- a/agent/tests/test_pipelines/test_1/test_influx_http.py
+++ b/agent/tests/test_pipelines/test_1/test_influx_http.py
@@ -24,6 +24,7 @@ class TestInflux(TestPipelineBase):
             {'name': 'test_influx_tag'},
             {'name': 'test_influx2_tag'},
             {'name': 'test_influx2_query_join'},
+            {'name': 'test_influx1_basic_auth'},
         ],
         'test_force_stop': [
             {'name': 'test_basic'},
@@ -41,6 +42,7 @@ class TestInflux(TestPipelineBase):
             {'name': 'test_influx_tag'},
             {'name': 'test_influx2_tag'},
             {'name': 'test_influx2_query_join'},
+            {'name': 'test_influx1_basic_auth'},
         ],
         'test_reset': [{'name': 'test_basic'}],
         'test_output': [
@@ -61,6 +63,7 @@ class TestInflux(TestPipelineBase):
             {'name': 'test_influx_schema_tag', 'output': 'influx_schema_tag.json', 'pipeline_type': 'influx'},
             {'name': 'test_influx2_tag', 'output': 'influx2_tag.json', 'pipeline_type': 'influx2'},
             {'name': 'test_influx2_query_join', 'output': 'influx2_query_join.json', 'pipeline_type': 'influx2'},
+            {'name': 'test_influx1_basic_auth', 'output': 'influx1_v2_basic_auth.json', 'pipeline_type': 'influx2'},
         ],
         'test_delete_pipeline': [
             {'name': 'test_basic'},
@@ -78,6 +81,7 @@ class TestInflux(TestPipelineBase):
             {'name': 'test_influx_tag'},
             {'name': 'test_influx2_tag'},
             {'name': 'test_influx2_query_join'},
+            {'name': 'test_influx1_basic_auth'},
         ],
         'test_source_delete': [
             {'name': 'test_influx'},
@@ -86,6 +90,7 @@ class TestInflux(TestPipelineBase):
             {'name': 'test_influx2'},
             {'name': 'test_influx2_file'},
             {'name': 'influx2_influxql_source'},
+            {'name': 'test_influx1_basic_auth'},
         ],
     }
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -149,6 +149,7 @@ services:
 #      INFLUXDB_ADMIN_PASSWORD: admin
 #      INFLUXDB_READ_USER: ro
 #      INFLUXDB_READ_USER_PASSWORD: roro
+      INFLUXDB_HTTP_FLUX_ENABLED: 'true'
 
   influx-2:
     image: influxdb:2.0.7

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -144,11 +144,11 @@ services:
       - ./volumes/influx-initdb:/docker-entrypoint-initdb.d
     environment:
       INFLUXDB_DB: test
-#      INFLUXDB_HTTP_AUTH_ENABLED: 'true'
-#      INFLUXDB_ADMIN_USER: admin
-#      INFLUXDB_ADMIN_PASSWORD: admin
-#      INFLUXDB_READ_USER: ro
-#      INFLUXDB_READ_USER_PASSWORD: roro
+      INFLUXDB_HTTP_AUTH_ENABLED: 'true'
+      INFLUXDB_ADMIN_USER: admin
+      INFLUXDB_ADMIN_PASSWORD: admin
+      INFLUXDB_READ_USER: ro
+      INFLUXDB_READ_USER_PASSWORD: roro
       INFLUXDB_HTTP_FLUX_ENABLED: 'true'
 
   influx-2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,11 +143,12 @@ services:
       - ./volumes/influx-initdb:/docker-entrypoint-initdb.d
     environment:
       INFLUXDB_DB: test
-  #      INFLUXDB_HTTP_AUTH_ENABLED: 'true'
-  #      INFLUXDB_ADMIN_USER: admin
-  #      INFLUXDB_ADMIN_PASSWORD: admin
-  #      INFLUXDB_READ_USER: ro
-  #      INFLUXDB_READ_USER_PASSWORD: roro
+      INFLUXDB_HTTP_AUTH_ENABLED: 'true'
+      INFLUXDB_ADMIN_USER: admin
+      INFLUXDB_ADMIN_PASSWORD: admin
+      INFLUXDB_READ_USER: ro
+      INFLUXDB_READ_USER_PASSWORD: roro
+      INFLUXDB_HTTP_FLUX_ENABLED: 'true'
 
   influx-2:
     image: influxdb:2.0.7


### PR DESCRIPTION
- Added Token to header for basic (user:password) auth
- 'org' param is not required for flux requests to DB v1.x
- Added filter for response processing, because request to /api/v2/query return a following response example
```csv
#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
#group,false,false,true,true,false,false,true,true,true,true
#default,_result,,,,,,,,,
,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
,,0,2019-03-10T12:53:00Z,2022-09-18T08:14:11.151147903Z,2019-03-19T00:13:46.168997Z,0.224,usage_active,cpu_test,cpu-total-usage,msk-air-trn1

#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
#group,false,false,true,true,false,false,true,true,true,true
#default,_result,,,,,,,,,
,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
,,1,2019-03-10T12:53:00Z,2022-09-18T08:14:11.151147903Z,2019-03-19T00:13:46.168997Z,14.247,usage_idle,cpu_test,cpu-total-usage,msk-air-trn1
```

Related ticket: [AL-11762](https://anodot.atlassian.net/browse/AL-11762)