### PR TITLE
[jdbc][databrix] Backfill missing intervals option

### DIFF
--- a/agent/src/agent/pipeline/config/stages/jdbc.py
+++ b/agent/src/agent/pipeline/config/stages/jdbc.py
@@ -1,3 +1,4 @@
+from urllib.parse import urljoin
 from agent import pipeline
 from agent.pipeline.config.stages.base import JythonSource, JythonProcessor
 
@@ -26,6 +27,14 @@ class JDBCOffsetScript(JythonSource):
             {
                 'key': 'TIMEZONE',
                 'value': str(self.pipeline.timezone),
+            },
+            {
+                'key': 'TRACK_MISSED_INTERVALS',
+                'value': 'True' if self.pipeline.config.get('track_missed_intervals', False) else ''
+            },
+            {
+                'key': 'PIPELINE_OFFSET_ENDPOINT',
+                'value': urljoin(self.pipeline.streamsets.agent_external_url, f'/pipeline-offset/{self.pipeline.name}')
             },
         ]
 


### PR DESCRIPTION
Added `track_missed_intervals` bool option for JDBC pipelines

This works as follows:
- If `track_missed_intervals == True`, last offset requested from DB
- If `db_offset` is behind current offset for at least two intervals -> firstly try to look at these intervals in the past. Request data starting from this `db_offset`.

Related ticket: [AL-12057](https://anodot.atlassian.net/browse/AL-12057)