### PR TITLE
[agent][jdbc] Fix query missing data logic

### DIFF
--- a/agent/src/agent/api/routes/pipeline.py
+++ b/agent/src/agent/api/routes/pipeline.py
@@ -183,7 +183,7 @@ def pipeline_offset_changed(pipeline_id: str):
 @needs_pipeline
 def pipeline_offset_get(pipeline_id: str):
     pipeline_ = pipeline.repository.get_by_id(pipeline_id)
-    return pipeline_.offset.offset if pipeline_.offset else jsonify({})
+    return jsonify({'timestamp': pipeline_.offset.timestamp}) if pipeline_.offset else jsonify({})
 
 
 @pipelines.route('/pipelines/<pipeline_id>/watermark', methods=['POST'])

--- a/agent/src/agent/pipeline/config/jython_scripts/jdbc.py
+++ b/agent/src/agent/pipeline/config/jython_scripts/jdbc.py
@@ -51,7 +51,7 @@ def query_missing_data(main_offset, main_interval):
     start = main_offset - main_interval * math.ceil((main_offset - db_offset) / main_interval)
 
     # search missing data points by buckets
-    while start < main_offset - main_interval:
+    while start < main_offset - main_interval and not sdc.isStopped():
         sdc.log.info('Processing missed data: from {} to {}'.format(str(datetime.fromtimestamp(start)), str(datetime.fromtimestamp(start + main_interval))))
         cur_batch = sdc.createBatch()
         record = sdc.createRecord('record created ' + str(datetime.now()))


### PR DESCRIPTION
- Update GET pipeline-offest API response
- If query_missing_data set: 
** Find the start timestamp of the bucket where the latest `db_offset` is
** Bucket-by-bucket request missing data points
** Break when `current_offset` reached

Related ticket: [AL-12057](https://anodot.atlassian.net/browse/AL-12057), [SE-3696](https://anodot.atlassian.net/browse/SE-3696)