### PR TITLE
[agent][docker] Fixed codename of agent's Linux distribution for apt

### DIFF
--- a/agent/install_requirements.sh
+++ b/agent/install_requirements.sh
@@ -5,7 +5,7 @@ set -e
 # adding new repo to install correct postgres-client version
 wget --no-check-certificate --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 # using stretch instead of `lsb_release -cs`-pgdg main as it's not working with the current version
-echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
 apt update && apt install -y --reinstall vim netcat curl nano ca-certificates postgresql-client-12 librrd-dev default-mysql-client kafkacat
 


### PR DESCRIPTION
Change the distributions codename used during postgresql-client install
```
# cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
```